### PR TITLE
Update erlef/setup-beam action in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
             repo.hex.pm:443
 
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: erlef/setup-elixir@e3f6ffe2878180f57318bf13febd3933ee81f664 # v1.15.2
+      - uses: erlef/setup-beam@61e01a43a562a89bfc54c7f9a378ff67b03e4a21 # v1.16.0
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}


### PR DESCRIPTION
## Description

The CD file erlef dependence was not up to date and was generating an error in the action that delivers the new version release to hex