### PR TITLE
Allow to use simulate tx in contract functions invocation

### DIFF
--- a/lib/contract.ex
+++ b/lib/contract.ex
@@ -12,7 +12,7 @@ defmodule Soroban.Contract do
   }
 
   defdelegate invoke(
-                contract_id,
+                contract_address,
                 source_secret_key,
                 function_name,
                 function_args \\ [],
@@ -20,6 +20,15 @@ defmodule Soroban.Contract do
               ),
               to: InvokeContractFunction,
               as: :invoke
+
+  defdelegate simulate_invoke(
+                contract_address,
+                source_public_key,
+                function_name,
+                function_args \\ []
+              ),
+              to: InvokeContractFunction,
+              as: :simulate_invoke
 
   defdelegate upload(
                 wasm,
@@ -55,7 +64,7 @@ defmodule Soroban.Contract do
     as: :bump_contract_keys
 
   defdelegate retrieve_unsigned_xdr_to_invoke(
-                contract_id,
+                contract_address,
                 source_public_key,
                 function_name,
                 function_args \\ []

--- a/lib/contract/invoke_contract_function.ex
+++ b/lib/contract/invoke_contract_function.ex
@@ -4,7 +4,7 @@ defmodule Soroban.Contract.InvokeContractFunction do
   """
 
   alias Soroban.Contract.RPCCalls
-  alias Soroban.RPC.SendTransactionResponse
+  alias Soroban.RPC.{SendTransactionResponse, SimulateTransactionResponse}
   alias Soroban.Types.Address
 
   alias Stellar.Horizon.Accounts

--- a/test/contract/invoke_contract_function_test.exs
+++ b/test/contract/invoke_contract_function_test.exs
@@ -380,6 +380,37 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
       )
   end
 
+  test "simulate invoke", %{
+    contract_id: contract_id,
+    source_public: source_public,
+    function_name: function_name,
+    function_args: function_args
+  } do
+    {:ok,
+     %SimulateTransactionResponse{
+       transaction_data:
+         "AAAAAAAAAAIAAAAGAAAAAfZ2qpskZkwsIQ1nJ2CcyvWbV+064IzGKhcEFrM3F9EgAAAAFAAAAAEAAAAAAAAAB5g18rNSrgYpg/O7tgIlBv42+QqjpEFv6gEqW+oDFUZbAAAAAAAAAAAANYvgAAAUOAAAAAAAAADwAAAAAAAAAC8=",
+       events: nil,
+       min_resource_fee: "79488",
+       results: [
+         %{
+           auth: nil,
+           events: nil,
+           xdr: "AAAAEAAAAAEAAAACAAAADwAAAAVIZWxsbwAAAAAAAA8AAAAFd29ybGQAAAA="
+         }
+       ],
+       cost: %{cpu_insns: "1052105", mem_bytes: "1201148"},
+       latest_ledger: "690189",
+       error: nil
+     }} =
+      InvokeContractFunction.simulate_invoke(
+        contract_id,
+        source_public,
+        function_name,
+        function_args
+      )
+  end
+
   test "invoke host function invalid length of auth keys", %{
     contract_id: contract_id,
     source_secret_auths_error: source_secret_auths_error,

--- a/test/contract/invoke_contract_function_test.exs
+++ b/test/contract/invoke_contract_function_test.exs
@@ -292,7 +292,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
     end)
 
     %{
-      contract_id: "CD3HNKU3ERTEYLBBBVTSOYE4ZL2ZWV7NHLQIZRRKC4CBNMZXC7ISBXHV",
+      contract_address: "CD3HNKU3ERTEYLBBBVTSOYE4ZL2ZWV7NHLQIZRRKC4CBNMZXC7ISBXHV",
       source_public: "GDEU46HFMHBHCSFA3K336I3MJSBZCWVI3LUGSNL6AF2BW2Q2XR7NNAPM",
       # GBNDWIM7DPYZJ2RLJ3IESXBIO4C2SVF6PWZXS3DLODJSBQWBMKY5U4M3
       source_secret: "SDRD4CSRGPWUIPRDS5O3CJBNJME5XVGWNI677MZDD4OD2ZL2R6K5IQ24",
@@ -313,7 +313,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   end
 
   test "invoke host function without authorization", %{
-    contract_id: contract_id,
+    contract_address: contract_address,
     source_secret: source_secret,
     function_name: function_name,
     function_args: function_args
@@ -327,7 +327,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
        error_result_xdr: nil
      }} =
       InvokeContractFunction.invoke(
-        contract_id,
+        contract_address,
         source_secret,
         function_name,
         function_args
@@ -335,7 +335,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   end
 
   test "invoke host function without signed authorization", %{
-    contract_id: contract_id,
+    contract_address: contract_address,
     source_secret_with_auth: source_secret_with_auth,
     function_name: function_name,
     function_args: function_args
@@ -349,7 +349,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
        error_result_xdr: nil
      }} =
       InvokeContractFunction.invoke(
-        contract_id,
+        contract_address,
         source_secret_with_auth,
         function_name,
         function_args
@@ -357,7 +357,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   end
 
   test "invoke host function with signed authorization", %{
-    contract_id: contract_id,
+    contract_address: contract_address,
     source_secret_with_auths: source_secret_with_auths,
     function_name: function_name,
     function_args: function_args,
@@ -372,7 +372,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
        error_result_xdr: nil
      }} =
       InvokeContractFunction.invoke(
-        contract_id,
+        contract_address,
         source_secret_with_auths,
         function_name,
         function_args,
@@ -381,7 +381,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   end
 
   test "simulate invoke", %{
-    contract_id: contract_id,
+    contract_address: contract_address,
     source_public: source_public,
     function_name: function_name,
     function_args: function_args
@@ -404,7 +404,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
        error: nil
      }} =
       InvokeContractFunction.simulate_invoke(
-        contract_id,
+        contract_address,
         source_public,
         function_name,
         function_args
@@ -412,7 +412,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   end
 
   test "invoke host function invalid length of auth keys", %{
-    contract_id: contract_id,
+    contract_address: contract_address,
     source_secret_auths_error: source_secret_auths_error,
     function_name: function_name,
     function_args: function_args,
@@ -420,7 +420,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   } do
     {:error, :invalid_auth_secret_keys_length} =
       InvokeContractFunction.invoke(
-        contract_id,
+        contract_address,
         source_secret_auths_error,
         function_name,
         function_args,
@@ -429,7 +429,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   end
 
   test "invoke host function with simulate error", %{
-    contract_id: contract_id,
+    contract_address: contract_address,
     source_secret_with_error: source_secret_with_error,
     function_name: function_name,
     function_args: function_args
@@ -439,7 +439,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
        error: "error"
      }} =
       InvokeContractFunction.invoke(
-        contract_id,
+        contract_address,
         source_secret_with_error,
         function_name,
         function_args
@@ -447,7 +447,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   end
 
   test "retrieve_unsigned_xdr_to_invoke without authorization", %{
-    contract_id: contract_id,
+    contract_address: contract_address,
     source_public: source_public,
     function_name: function_name,
     function_args: function_args,
@@ -455,7 +455,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   } do
     ^xdr_envelope =
       InvokeContractFunction.retrieve_unsigned_xdr_to_invoke(
-        contract_id,
+        contract_address,
         source_public,
         function_name,
         function_args
@@ -463,7 +463,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
   end
 
   test "retrieve_unsigned_xdr_to_invoke host function with simulate error", %{
-    contract_id: contract_id,
+    contract_address: contract_address,
     source_public_with_error: source_public_with_error,
     function_name: function_name,
     function_args: function_args
@@ -473,7 +473,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
        error: "error"
      }} =
       InvokeContractFunction.retrieve_unsigned_xdr_to_invoke(
-        contract_id,
+        contract_address,
         source_public_with_error,
         function_name,
         function_args

--- a/test/contract_test.exs
+++ b/test/contract_test.exs
@@ -181,7 +181,7 @@ defmodule Soroban.ContractTest do
   end
 
   test "simulate_invoke/5", %{
-    contract_id: contract_id,
+    contract_address: contract_address,
     source_public: source_public,
     function_name: function_name
   } do
@@ -199,7 +199,7 @@ defmodule Soroban.ContractTest do
        error: nil
      }} =
       Contract.simulate_invoke(
-        contract_id,
+        contract_address,
         source_public,
         function_name
       )

--- a/test/contract_test.exs
+++ b/test/contract_test.exs
@@ -68,7 +68,8 @@ defmodule Soroban.ContractTest do
 
   alias Soroban.RPC.{
     CannedContractClientImpl,
-    SendTransactionResponse
+    SendTransactionResponse,
+    SimulateTransactionResponse
   }
 
   alias Stellar.Horizon.Client.CannedContractAccountRequests
@@ -176,6 +177,31 @@ defmodule Soroban.ContractTest do
         function_name,
         function_args,
         auth_secret_keys
+      )
+  end
+
+  test "simulate_invoke/5", %{
+    contract_id: contract_id,
+    source_public: source_public,
+    function_name: function_name
+  } do
+    {:ok,
+     %SimulateTransactionResponse{
+       transaction_data:
+         "AAAAAAAAAAIAAAAGAAAAAfZ2qpskZkwsIQ1nJ2CcyvWbV+064IzGKhcEFrM3F9EgAAAAFAAAAAEAAAAAAAAAB5g18rNSrgYpg/O7tgIlBv42+QqjpEFv6gEqW+oDFUZbAAAAAAAAAAAANYvgAAAUOAAAAAAAAADwAAAAAAAAAC8=",
+       events: nil,
+       min_resource_fee: "79488",
+       results: [
+         %{auth: nil, xdr: "AAAAEAAAAAEAAAACAAAADwAAAAVIZWxsbwAAAAAAAA8AAAAFd29ybGQAAAA="}
+       ],
+       cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
+       latest_ledger: "475528",
+       error: nil
+     }} =
+      Contract.simulate_invoke(
+        contract_id,
+        source_public,
+        function_name
       )
   end
 


### PR DESCRIPTION
## Description

Allow to use simulate tx in contract functions invocation, so anyone can see directly the simulated result without the need of sending the tx to the network.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
