### PR TITLE
Update allowed endpoints in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604 # v2.5.0
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,7 @@ jobs:
             github.com:443
             hex.pm:443
             repo.hex.pm:443
+            builds.hex.pm:443
 
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: erlef/setup-beam@61e01a43a562a89bfc54c7f9a378ff67b03e4a21 # v1.16.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       MIX_ENV: test
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604 # v2.5.0
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             coveralls.io:443
             github.com:443
             repo.hex.pm:443
+            builds.hex.pm:443
 
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: erlef/setup-beam@61e01a43a562a89bfc54c7f9a378ff67b03e4a21 # v1.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## 0.13.0 (08.08.2023)
+## 0.13.0 (09.08.2023)
 
 - [Allow invocation with invoker authorization](https://github.com/kommitters/soroban.ex/issues/103).
 - [Add BumpFootprintExpiration operation](https://github.com/kommitters/soroban.ex/issues/104).
 - [Add RestoreFootprint operation](https://github.com/kommitters/soroban.ex/issues/105).
 - Allow to use simulate tx in contract functions invocation.
 - Update all dependencies.
+- Add `builds.hex.pm` to allowed-endpoints in CD.
 
 ## 0.12.0 (28.07.2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Allow to use simulate tx in contract functions invocation.
 - Update all dependencies.
 - Add `builds.hex.pm` to allowed-endpoints in CD.
+- Update harden-runner action to v2.5.1.
 
 ## 0.12.0 (28.07.2023)
 


### PR DESCRIPTION
Dependencies were updated. However, the scorecard workflow failed because, as a result of the update, requests were made to endpoints that were not on the allowed list.

See https://github.com/kommitters/soroban.ex/actions/runs/5802759829
See https://app.stepsecurity.io/github/kommitters/soroban.ex/actions/runs/5802759829