### PR TITLE
Add additional networks rpc endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Struct.new([field1, field2])
 
 Interaction with the Soroban-RPC server is done through the `Soroban.RPC` module.
 
-To interact with another network than the futurenet, you can change the `:stellar_sdk` config, which will also change to the RPC endpoint that works with that network. e.g.
+Currently, `Soroban.ex` can run on `Futurenet`, `Testnet`, and `Local`, the former being the default network. To use the `Testnet` network change the :stellar_sdk setting, which will also change to the RPC endpoint that works with that network. e.g.
 
 ```elixir
 config :stellar_sdk, network: :test

--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ Struct.new([field1, field2])
 
 Interaction with the Soroban-RPC server is done through the `Soroban.RPC` module.
 
+To interact with another network than the futurenet, you can change the `:stellar_sdk` config, which will also change to the RPC endpoint that works with that network. e.g.
+
+```elixir
+config :stellar_sdk, network: :test
+```
+
 #### Simulate Transaction
 
 Submit a trial contract invocation to get back return values, expected ledger footprint, and expected costs.

--- a/lib/rpc/request.ex
+++ b/lib/rpc/request.ex
@@ -7,7 +7,11 @@ defmodule Soroban.RPC.Request do
 
   alias Soroban.RPC.{Client, Error, HTTPError}
 
-  @default_url "https://rpc-futurenet.stellar.org:443/"
+  @base_urls [
+    test: "https://soroban-testnet.stellar.org",
+    future: "https://rpc-futurenet.stellar.org",
+    local: "http://localhost:8000"
+  ]
 
   @type endpoint :: String.t()
   @type headers :: [{binary(), binary()}]
@@ -33,7 +37,8 @@ defmodule Soroban.RPC.Request do
 
   @spec new(endpoint :: endpoint(), opts :: opts()) :: t()
   def new(endpoint, opts \\ []) do
-    url = Keyword.get(opts, :url, @default_url)
+    default = @base_urls[:future]
+    url = Keyword.get(opts, :url) || Keyword.get(@base_urls, current_network(), default)
 
     %__MODULE__{
       endpoint: endpoint,
@@ -57,4 +62,7 @@ defmodule Soroban.RPC.Request do
   @spec results(response :: response(), opts :: opts()) :: parsed_response()
   def results({:ok, results}, as: resource), do: {:ok, resource.new(results)}
   def results({:error, error}, _resource), do: {:error, error}
+
+  @spec current_network() :: atom()
+  defp current_network, do: Application.get_env(:stellar_sdk, :network, :future)
 end

--- a/test/rpc/request_test.exs
+++ b/test/rpc/request_test.exs
@@ -29,7 +29,7 @@ defmodule Soroban.RPC.RequestTest do
       Application.delete_env(:soroban, :http_client_impl)
     end)
 
-    url = "https://rpc-futurenet.stellar.org:443/"
+    url = "https://rpc-futurenet.stellar.org"
     headers = [{"Content-Type", "application/json"}]
     endpoint = "getTransaction"
 


### PR DESCRIPTION
## Description

Add support to testnet and local RPC endpoints when the requests are performed.  Allowing to work with testnet and a local network via env configurations. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
