### PR TITLE
Remove percentages of additional resources + update SimulateTransactionResponse 

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Soroban.RPC.simulate_transaction(base64_envelope)
      }
    ],
    cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-   latest_ledger: "475528",
+   latest_ledger: 45075181,
    error: nil
  }}
 
@@ -263,7 +263,7 @@ Soroban.RPC.send_transaction(base64_envelope)
  %Soroban.RPC.SendTransactionResponse{
    status: "PENDING",
    hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-   latest_ledger: "476420",
+   latest_ledger: 45075181,
    latest_ledger_close_time: "1683150612",
    error_result_xdr: nil
  }}
@@ -288,7 +288,7 @@ Soroban.RPC.get_transaction(hash)
 {:ok,
  %Soroban.RPC.GetTransactionResponse{
    status: "SUCCESS",
-   latest_ledger: "476536",
+   latest_ledger: 45075181,
    latest_ledger_close_time: "1683151229",
    oldest_ledger: "475097",
    oldest_ledger_close_time: "1683143656",
@@ -380,7 +380,7 @@ Soroban.RPC.get_ledger_entries(keys)
        live_until_ledger_seq: "320384"
      }
    ],
-   latest_ledger: "179436"
+   latest_ledger: 45075181
  }}
 
 ```
@@ -450,7 +450,7 @@ Soroban.RPC.get_events(events_payload)
 
 {:ok,
  %Soroban.RPC.GetEventsResponse{
-   latest_ledger: "685870",
+   latest_ledger: 45075181,
    events: [
      %{
        contract_id: "CCEMOFO5TE7FGOAJOA3RDHPC6RW3CFXRVIGOFQPFE4ZGOKA2QEA636SN",
@@ -506,7 +506,7 @@ Contract.invoke(contract_address, source_secret_key, function_name, function_arg
   %Soroban.RPC.SendTransactionResponse{
     status: "PENDING",
     hash: "f62cb9e20c6d297316f49dca2041be4bf1af6b069c784764e51ac008b313d716",
-    latest_ledger: "570194",
+    latest_ledger: 45075181,
     latest_ledger_close_time: "1683643419",
     error_result_xdr: nil
   }}
@@ -536,7 +536,7 @@ Contract.invoke(contract_address, source_secret_key, function_name, function_arg
     %Soroban.RPC.SendTransactionResponse{
       status: "PENDING",
       hash: "e888193b4fed9b3ca6ad2beca3c1ed5bef3e0099e558756de85d03511cbaa00b",
-      latest_ledger: "570253",
+      latest_ledger: 45075181,
       latest_ledger_close_time: "1683643728",
       error_result_xdr: nil
     }}
@@ -581,7 +581,7 @@ Contract.invoke(contract_address, source_secret_key, function_name, function_arg
     %Soroban.RPC.SendTransactionResponse{
       status: "PENDING",
       hash: "da263f59a8f8b29f415e7e26758cad6e8d88caec875112641b88757ce8e01873",
-      latest_ledger: "570349",
+      latest_ledger: 45075181,
       latest_ledger_close_time: "1683644240",
       error_result_xdr: nil
     }}
@@ -611,7 +611,7 @@ secret_key = "SCA..."
   %Soroban.RPC.SendTransactionResponse{
     status: "PENDING",
     hash: "65d...",
-    latest_ledger: "1",
+    latest_ledger: 45075181,
     latest_ledger_close_time: "16",
     error_result_xdr: nil
   }}
@@ -639,7 +639,7 @@ secret_key = "SCA..."
   %Soroban.RPC.SendTransactionResponse{
     status: "PENDING",
     hash: "f95...",
-    latest_ledger: "1",
+    latest_ledger: 45075181,
     latest_ledger_close_time: "16",
     error_result_xdr: nil
   }}
@@ -669,7 +669,7 @@ secret_key = "SCA..."
 %Soroban.RPC.SendTransactionResponse{
   status: "PENDING",
   hash: "b667...",
-  latest_ledger: "1",
+  latest_ledger: 45075181,
   latest_ledger_close_time: "16",
   error_result_xdr: nil
 }}
@@ -703,7 +703,7 @@ ledgers_to_extend = 100_000
  %Soroban.RPC.SendTransactionResponse{
    status: "PENDING",
    hash: "2f6f...",
-   latest_ledger: "279954",
+   latest_ledger: 45075181,
    latest_ledger_close_time: "1691441432",
    error_result_xdr: nil
 }}
@@ -735,7 +735,7 @@ ledgers_to_extend = 100_000
  %Soroban.RPC.SendTransactionResponse{
    status: "PENDING",
    hash: "2f6f...",
-   latest_ledger: "279954",
+   latest_ledger: 45075181,
    latest_ledger_close_time: "1691441432",
    error_result_xdr: nil
 }}
@@ -771,7 +771,7 @@ keys =  [{:persistent, "Prst"}, {:temporary, "Tmp"}]
  %Soroban.RPC.SendTransactionResponse{
    status: "PENDING",
    hash: "2f6f...",
-   latest_ledger: "279954",
+   latest_ledger: 45075181,
    latest_ledger_close_time: "1691441432",
    error_result_xdr: nil
 }}
@@ -803,7 +803,7 @@ secret_key = "SDRD4CSRGPWUIPRDS5O3CJBNJME5XVGWNI677MZDD4OD2ZL2R6K5IQ24"
  %Soroban.RPC.SendTransactionResponse{
    status: "PENDING",
    hash: "eedb...",
-   latest_ledger: "295506",
+   latest_ledger: 45075181,
    latest_ledger_close_time: "1691523150",
    error_result_xdr: nil
  }}
@@ -834,7 +834,7 @@ secret_key = "SDRD4CSRGPWUIPRDS5O3CJBNJME5XVGWNI677MZDD4OD2ZL2R6K5IQ24"
  %Soroban.RPC.SendTransactionResponse{
    status: "PENDING",
    hash: "eedb...",
-   latest_ledger: "295508",
+   latest_ledger: 45075181,
    latest_ledger_close_time: "1691523689",
    error_result_xdr: nil
  }}
@@ -870,7 +870,7 @@ keys =  [persistent: ["Prst"]]
  %Soroban.RPC.SendTransactionResponse{
    status: "PENDING",
    hash: "0521...",
-   latest_ledger: "295768",
+   latest_ledger: 45075181,
    latest_ledger_close_time: "1691524532",
    error_result_xdr: nil
  }}

--- a/lib/contract/rpc_calls.ex
+++ b/lib/contract/rpc_calls.ex
@@ -101,13 +101,6 @@ defmodule Soroban.Contract.RPCCalls do
       ) do
     with %InvokeHostFunction{} = invoke_host_function_op <-
            set_host_function_auth(operation, auth, auth_secret_keys) do
-      {transaction_data, min_resource_fee} =
-        process_transaction_response(
-          transaction_data,
-          String.to_integer(min_resource_fee),
-          auth_secret_keys
-        )
-
       %BaseFee{fee: base_fee} = BaseFee.new()
       fee = BaseFee.new(base_fee + min_resource_fee + round(min_resource_fee * extra_fee_rate))
 
@@ -140,13 +133,6 @@ defmodule Soroban.Contract.RPCCalls do
       )
       when is_nil(results) and is_binary(transaction_data) do
     with {:ok, operation} <- validate_operation(operation) do
-      {transaction_data, min_resource_fee} =
-        process_transaction_response(
-          transaction_data,
-          String.to_integer(min_resource_fee),
-          nil
-        )
-
       %BaseFee{fee: base_fee} = BaseFee.new()
       fee = BaseFee.new(base_fee + min_resource_fee + round(min_resource_fee * extra_fee_rate))
 
@@ -202,13 +188,6 @@ defmodule Soroban.Contract.RPCCalls do
         extra_fee_rate
       ) do
     invoke_host_function_op = set_host_function_auth(invoke_host_function_op, auth, [])
-
-    {transaction_data, min_resource_fee} =
-      process_transaction_response(
-        transaction_data,
-        String.to_integer(min_resource_fee),
-        nil
-      )
 
     %BaseFee{fee: base_fee} = BaseFee.new()
     fee = BaseFee.new(base_fee + min_resource_fee + round(min_resource_fee * extra_fee_rate))
@@ -283,31 +262,4 @@ defmodule Soroban.Contract.RPCCalls do
   @spec validate_operation(operation :: footprint_operations()) :: validation()
   defp validate_operation(%ExtendFootprintTTL{} = operation), do: {:ok, operation}
   defp validate_operation(%RestoreFootprint{} = operation), do: {:ok, operation}
-
-  # This function is needed since when the function invoker is not the function authorizer
-  # the transaction data returns min_resource_fee and instructions with wrong values.
-  # More info: https://discord.com/channels/897514728459468821/1112853306881081354
-  @spec process_transaction_response(
-          transaction_data :: String.t(),
-          min_resource_fee :: non_neg_integer(),
-          auth_secret_key :: auth_secret_key()
-        ) :: {SorobanTransactionData.t(), non_neg_integer()}
-  defp process_transaction_response(transaction_data, min_resource_fee, nil),
-    do: {transaction_data, min_resource_fee}
-
-  defp process_transaction_response(transaction_data, min_resource_fee, _auth_secret_key) do
-    {%{
-       resources: %{instructions: %{datum: datum}} = resources
-     } = soroban_data,
-     ""} =
-      transaction_data
-      |> Base.decode64!()
-      |> SorobanTransactionData.decode_xdr!()
-
-    new_instructions = UInt32.new(datum + round(datum * 0.25))
-    new_resources = %{resources | instructions: new_instructions}
-    soroban_data = %{soroban_data | resources: new_resources}
-    min_resource_fee = min_resource_fee + round(min_resource_fee * 0.1)
-    {soroban_data, min_resource_fee}
-  end
 end

--- a/lib/rpc/responses/simulate_transaction_response.ex
+++ b/lib/rpc/responses/simulate_transaction_response.ex
@@ -4,27 +4,47 @@ defmodule Soroban.RPC.SimulateTransactionResponse do
   """
   @behaviour Soroban.RPC.Response.Spec
 
-  @type results :: list(map())
+  @type min_resource_fee :: non_neg_integer()
   @type cost :: map()
-  @type latest_ledger :: String.t()
+  @type results :: list(map())
+  @type transaction_data :: String.t()
+  @type events :: list(String.t())
+  @type restore_preamble :: map() | nil
+  @type latest_ledger :: non_neg_integer()
   @type error :: String.t() | nil
+
   @type t :: %__MODULE__{
-          results: results(),
+          min_resource_fee: min_resource_fee(),
           cost: cost(),
+          results: results(),
+          transaction_data: transaction_data(),
+          events: events(),
+          restore_preamble: restore_preamble(),
           latest_ledger: latest_ledger(),
           error: error()
         }
 
   defstruct [
+    :min_resource_fee,
+    :cost,
+    :results,
     :transaction_data,
     :events,
-    :min_resource_fee,
-    :results,
-    :cost,
+    :restore_preamble,
     :latest_ledger,
     :error
   ]
 
   @impl true
-  def new(attrs), do: struct(%__MODULE__{}, attrs)
+  def new(attrs) do
+    # If :min_resource_fee is present, convert it to an integer
+    new_attrs =
+      if Map.has_key?(attrs, :min_resource_fee) do
+        Map.put(attrs, :min_resource_fee, String.to_integer(attrs.min_resource_fee))
+      else
+        attrs
+      end
+
+    struct(%__MODULE__{}, new_attrs)
+  end
 end

--- a/lib/rpc/responses/simulate_transaction_response.ex
+++ b/lib/rpc/responses/simulate_transaction_response.ex
@@ -37,7 +37,6 @@ defmodule Soroban.RPC.SimulateTransactionResponse do
 
   @impl true
   def new(attrs) do
-    # If :min_resource_fee is present, convert it to an integer
     new_attrs =
       if Map.has_key?(attrs, :min_resource_fee) do
         Map.put(attrs, :min_resource_fee, String.to_integer(attrs.min_resource_fee))

--- a/test/contract/deploy_asset_contract_test.exs
+++ b/test/contract/deploy_asset_contract_test.exs
@@ -42,7 +42,7 @@ defmodule Soroban.RPC.CannedDeployAssetInvokeHostFunctionClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -54,7 +54,7 @@ defmodule Soroban.RPC.CannedDeployAssetInvokeHostFunctionClientImpl do
      %{
        status: "PENDING",
        hash: "308f5f3c7b2c0a690e7e19b6d14c22af87763f5ae483d6d1af43b9639732d206",
-       latest_ledger: "602691",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683814245"
      }}
   end
@@ -105,7 +105,7 @@ defmodule Soroban.Contract.DeployAssetContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "308f5f3c7b2c0a690e7e19b6d14c22af87763f5ae483d6d1af43b9639732d206",
-       latest_ledger: "602691",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683814245",
        error_result_xdr: nil
      }} = DeployAssetContract.deploy(asset_code, source_public, source_secret)
@@ -120,7 +120,7 @@ defmodule Soroban.Contract.DeployAssetContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "308f5f3c7b2c0a690e7e19b6d14c22af87763f5ae483d6d1af43b9639732d206",
-       latest_ledger: "602691",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683814245",
        error_result_xdr: nil
      }} = DeployAssetContract.deploy(asset_code, asset_issuer, source_secret)

--- a/test/contract/deploy_contract_test.exs
+++ b/test/contract/deploy_contract_test.exs
@@ -54,7 +54,7 @@ defmodule Soroban.RPC.CannedDeployInvokeHostFunctionClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -66,7 +66,7 @@ defmodule Soroban.RPC.CannedDeployInvokeHostFunctionClientImpl do
      %{
        status: "PENDING",
        hash: "308f5f3c7b2c0a690e7e19b6d14c22af87763f5ae483d6d1af43b9639732d206",
-       latest_ledger: "602691",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683814245"
      }}
   end
@@ -112,7 +112,7 @@ defmodule Soroban.Contract.DeployContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "308f5f3c7b2c0a690e7e19b6d14c22af87763f5ae483d6d1af43b9639732d206",
-       latest_ledger: "602691",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683814245",
        error_result_xdr: nil
      }} = DeployContract.deploy(wasm_id, source_secret)

--- a/test/contract/extend_footprint_ttl_test.exs
+++ b/test/contract/extend_footprint_ttl_test.exs
@@ -40,7 +40,7 @@ defmodule Soroban.RPC.CannedExtendFootprintTTLClientImpl do
        min_resource_fee: "79488",
        results: nil,
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -64,7 +64,7 @@ defmodule Soroban.RPC.CannedExtendFootprintTTLClientImpl do
        min_resource_fee: "79488",
        results: nil,
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -88,7 +88,7 @@ defmodule Soroban.RPC.CannedExtendFootprintTTLClientImpl do
        min_resource_fee: "79488",
        results: nil,
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -100,7 +100,7 @@ defmodule Soroban.RPC.CannedExtendFootprintTTLClientImpl do
      %{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612"
      }}
   end
@@ -158,7 +158,7 @@ defmodule Soroban.Contract.ExtendFootprintTTLTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -190,7 +190,7 @@ defmodule Soroban.Contract.ExtendFootprintTTLTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -211,7 +211,7 @@ defmodule Soroban.Contract.ExtendFootprintTTLTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =

--- a/test/contract/invoke_contract_function_test.exs
+++ b/test/contract/invoke_contract_function_test.exs
@@ -95,7 +95,7 @@ defmodule Soroban.RPC.CannedInvokeContractFunctionClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -124,7 +124,7 @@ defmodule Soroban.RPC.CannedInvokeContractFunctionClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -144,7 +144,7 @@ defmodule Soroban.RPC.CannedInvokeContractFunctionClientImpl do
      %{
        error: "error",
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -176,7 +176,7 @@ defmodule Soroban.RPC.CannedInvokeContractFunctionClientImpl do
          }
        ],
        cost: %{cpu_insns: "1052105", mem_bytes: "1201148"},
-       latest_ledger: "690189",
+       latest_ledger: 45_075_181,
        error: nil
      }}
   end
@@ -208,7 +208,7 @@ defmodule Soroban.RPC.CannedInvokeContractFunctionClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -240,7 +240,7 @@ defmodule Soroban.RPC.CannedInvokeContractFunctionClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -252,7 +252,7 @@ defmodule Soroban.RPC.CannedInvokeContractFunctionClientImpl do
      %{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612"
      }}
   end
@@ -325,7 +325,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -347,7 +347,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -371,7 +371,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -396,7 +396,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
        transaction_data:
          "AAAAAAAAAAEAAAAHjDfZjX1lF+yHF4743DgE1KQTRmGJtwRYh3hJXOzQ9k8AAAABAAAABgAAAAEJjPko7iuhBRtsY0aDQ2Einilpmj/rDyGds/qx5seSNAAAABQAAAABAFBD8gAAGPAAAAEkAAAAAAAAAAY=",
        events: nil,
-       min_resource_fee: "79488",
+       min_resource_fee: 79488,
        results: [
          %{
            auth: [
@@ -406,7 +406,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528",
+       latest_ledger: 45_075_181,
        error: nil
      }} =
       InvokeContractFunction.simulate_invoke(

--- a/test/contract/invoke_contract_function_test.exs
+++ b/test/contract/invoke_contract_function_test.exs
@@ -396,7 +396,7 @@ defmodule Soroban.Contract.InvokeContractFunctionTest do
        transaction_data:
          "AAAAAAAAAAEAAAAHjDfZjX1lF+yHF4743DgE1KQTRmGJtwRYh3hJXOzQ9k8AAAABAAAABgAAAAEJjPko7iuhBRtsY0aDQ2Einilpmj/rDyGds/qx5seSNAAAABQAAAABAFBD8gAAGPAAAAEkAAAAAAAAAAY=",
        events: nil,
-       min_resource_fee: 79488,
+       min_resource_fee: 79_488,
        results: [
          %{
            auth: [

--- a/test/contract/restore_footprint_test.exs
+++ b/test/contract/restore_footprint_test.exs
@@ -40,7 +40,7 @@ defmodule Soroban.RPC.CannedRestoreFootprintClientImpl do
        min_resource_fee: "79488",
        results: nil,
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -64,7 +64,7 @@ defmodule Soroban.RPC.CannedRestoreFootprintClientImpl do
        min_resource_fee: "79488",
        results: nil,
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -88,7 +88,7 @@ defmodule Soroban.RPC.CannedRestoreFootprintClientImpl do
        min_resource_fee: "79488",
        results: nil,
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -100,7 +100,7 @@ defmodule Soroban.RPC.CannedRestoreFootprintClientImpl do
      %{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612"
      }}
   end
@@ -155,7 +155,7 @@ defmodule Soroban.Contract.RestoreFootprintTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -173,7 +173,7 @@ defmodule Soroban.Contract.RestoreFootprintTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -191,7 +191,7 @@ defmodule Soroban.Contract.RestoreFootprintTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =

--- a/test/contract/upload_contract_code_test.exs
+++ b/test/contract/upload_contract_code_test.exs
@@ -56,7 +56,7 @@ defmodule Soroban.RPC.CannedUploadInvokeHostFunctionClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -76,7 +76,7 @@ defmodule Soroban.RPC.CannedUploadInvokeHostFunctionClientImpl do
      %{
        error: "error",
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -88,7 +88,7 @@ defmodule Soroban.RPC.CannedUploadInvokeHostFunctionClientImpl do
      %{
        status: "PENDING",
        hash: "308f5f3c7b2c0a690e7e19b6d14c22af87763f5ae483d6d1af43b9639732d206",
-       latest_ledger: "602691",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683814245"
      }}
   end
@@ -138,7 +138,7 @@ defmodule Soroban.Contract.UploadContractCodeTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "308f5f3c7b2c0a690e7e19b6d14c22af87763f5ae483d6d1af43b9639732d206",
-       latest_ledger: "602691",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683814245",
        error_result_xdr: nil
      }} = UploadContractCode.upload(wasm, source_secret)

--- a/test/contract_test.exs
+++ b/test/contract_test.exs
@@ -131,7 +131,7 @@ defmodule Soroban.RPC.CannedContractClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 
@@ -143,7 +143,7 @@ defmodule Soroban.RPC.CannedContractClientImpl do
      %{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612"
      }}
   end
@@ -157,7 +157,7 @@ defmodule Soroban.RPC.CannedContractClientImpl do
        min_resource_fee: "79488",
        results: nil,
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 end
@@ -226,7 +226,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -247,7 +247,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -270,7 +270,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -295,7 +295,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -319,12 +319,12 @@ defmodule Soroban.ContractTest do
        transaction_data:
          "AAAAAAAAAAIAAAAGAAAAAQmM+SjuK6EFG2xjRoNDYSKeKWmaP+sPIZ2z+rHmx5I0AAAAFAAAAAEAAAAHjDfZjX1lF+yHF4743DgE1KQTRmGJtwRYh3hJXOzQ9k8AAAAAAE74MAAAGPAAAAAAAAAAAAAAAA0=",
        events: nil,
-       min_resource_fee: "79488",
+       min_resource_fee: 79488,
        results: [
          %{auth: nil, xdr: "AAAAEAAAAAEAAAACAAAADwAAAAVIZWxsbwAAAAAAAA8AAAAFd29ybGQAAAA="}
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528",
+       latest_ledger: 45_075_181,
        error: nil
      }} =
       Contract.simulate_invoke(
@@ -342,7 +342,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -360,7 +360,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -379,7 +379,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -399,7 +399,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -419,7 +419,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -440,7 +440,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -460,7 +460,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -478,7 +478,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =
@@ -496,7 +496,7 @@ defmodule Soroban.ContractTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} =

--- a/test/contract_test.exs
+++ b/test/contract_test.exs
@@ -319,7 +319,7 @@ defmodule Soroban.ContractTest do
        transaction_data:
          "AAAAAAAAAAIAAAAGAAAAAQmM+SjuK6EFG2xjRoNDYSKeKWmaP+sPIZ2z+rHmx5I0AAAAFAAAAAEAAAAHjDfZjX1lF+yHF4743DgE1KQTRmGJtwRYh3hJXOzQ9k8AAAAAAE74MAAAGPAAAAAAAAAAAAAAAA0=",
        events: nil,
-       min_resource_fee: 79488,
+       min_resource_fee: 79_488,
        results: [
          %{auth: nil, xdr: "AAAAEAAAAAEAAAACAAAADwAAAAVIZWxsbwAAAAAAAA8AAAAFd29ybGQAAAA="}
        ],

--- a/test/rpc/endpoints/get_events_test.exs
+++ b/test/rpc/endpoints/get_events_test.exs
@@ -9,7 +9,7 @@ defmodule Soroban.RPC.CannedGetEventsClientImpl do
 
     {:ok,
      %{
-       latest_ledger: "685196",
+       latest_ledger: 45_075_181,
        events: [
          %{
            contract_id: "CCEMOFO5TE7FGOAJOA3RDHPC6RW3CFXRVIGOFQPFE4ZGOKA2QEA636SN",
@@ -76,7 +76,7 @@ defmodule Soroban.RPC.GetEventsTest do
   test "request/1", %{event: event} do
     {:ok,
      %GetEventsResponse{
-       latest_ledger: "685196",
+       latest_ledger: 45_075_181,
        events: [
          %{
            contract_id: "CCEMOFO5TE7FGOAJOA3RDHPC6RW3CFXRVIGOFQPFE4ZGOKA2QEA636SN",

--- a/test/rpc/endpoints/get_ledger_entries_test.exs
+++ b/test/rpc/endpoints/get_ledger_entries_test.exs
@@ -16,7 +16,7 @@ defmodule Soroban.RPC.CannedGetLedgerEntriesClientImpl do
            last_modified_ledger_seq: "13"
          }
        ],
-       latest_ledger: "179436"
+       latest_ledger: 45_075_181
      }}
   end
 end
@@ -50,7 +50,7 @@ defmodule Soroban.RPC.GetLedgerEntriesTest do
            last_modified_ledger_seq: "13"
          }
        ],
-       latest_ledger: "179436"
+       latest_ledger: 45_075_181
      }} = GetLedgerEntries.request(keys)
   end
 end

--- a/test/rpc/endpoints/get_transaction_test.exs
+++ b/test/rpc/endpoints/get_transaction_test.exs
@@ -10,7 +10,7 @@ defmodule Soroban.RPC.GetTransactionCannedClientImpl do
     {:ok,
      %{
        status: "SUCCESS",
-       latest_ledger: "476536",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683151229",
        oldest_ledger: "475097",
        oldest_ledger_close_time: "1683143656",
@@ -51,7 +51,7 @@ defmodule Soroban.RPC.GetTransactionTest do
     {:ok,
      %GetTransactionResponse{
        status: "SUCCESS",
-       latest_ledger: "476536",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683151229",
        oldest_ledger: "475097",
        oldest_ledger_close_time: "1683143656",

--- a/test/rpc/endpoints/send_transaction_test.exs
+++ b/test/rpc/endpoints/send_transaction_test.exs
@@ -11,7 +11,7 @@ defmodule Soroban.RPC.SendTransactionCannedClientImpl do
      %{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612"
      }}
   end
@@ -44,7 +44,7 @@ defmodule Soroban.RPC.SendTransactionTest do
      %SendTransactionResponse{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612",
        error_result_xdr: nil
      }} = SendTransaction.request(transaction_xdr)

--- a/test/rpc/endpoints/simulate_transaction_test.exs
+++ b/test/rpc/endpoints/simulate_transaction_test.exs
@@ -20,7 +20,7 @@ defmodule Soroban.RPC.SimulateTransactionCannedClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 end
@@ -53,7 +53,7 @@ defmodule Soroban.RPC.SimulateTransactionTest do
        transaction_data:
          "AAAAAwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcAAAAG4avr0cYyEk0etiaStUgJ889XGSqUqZEZcCyR+ma87LIAAAAUAAAAB8zDhJ3ZTMHmdBjlVh/7d1HDdo+QI1ZXGmeRzBwVAoVXAAAAAQAAAAbhq+vRxjISTR62JpK1SAnzz1cZKpSpkRlwLJH6ZrzssgAAABUAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3ACb/vgAAFcQAAAC0AAABrAAAAAAAAABUAAAAAA==",
        events: nil,
-       min_resource_fee: "79488",
+       min_resource_fee: 79488,
        results: [
          %{
            auth: nil,
@@ -61,7 +61,7 @@ defmodule Soroban.RPC.SimulateTransactionTest do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528",
+       latest_ledger: 45_075_181,
        error: nil
      }} = SimulateTransaction.request(transaction_xdr)
   end

--- a/test/rpc/endpoints/simulate_transaction_test.exs
+++ b/test/rpc/endpoints/simulate_transaction_test.exs
@@ -53,7 +53,7 @@ defmodule Soroban.RPC.SimulateTransactionTest do
        transaction_data:
          "AAAAAwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcAAAAG4avr0cYyEk0etiaStUgJ889XGSqUqZEZcCyR+ma87LIAAAAUAAAAB8zDhJ3ZTMHmdBjlVh/7d1HDdo+QI1ZXGmeRzBwVAoVXAAAAAQAAAAbhq+vRxjISTR62JpK1SAnzz1cZKpSpkRlwLJH6ZrzssgAAABUAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3ACb/vgAAFcQAAAC0AAABrAAAAAAAAABUAAAAAA==",
        events: nil,
-       min_resource_fee: 79488,
+       min_resource_fee: 79_488,
        results: [
          %{
            auth: nil,

--- a/test/rpc/responses/get_event_response_test.exs
+++ b/test/rpc/responses/get_event_response_test.exs
@@ -6,7 +6,7 @@ defmodule Soroban.RPC.GetEventsResponseTest do
   setup do
     %{
       result: %{
-        latest_ledger: "669450",
+        latest_ledger: 45_075_181,
         events: [
           %{
             contract_id: "6e34123e6328b38075f4e670175221452db7535ceeb3def1af6dddc232c1eae4",
@@ -32,7 +32,7 @@ defmodule Soroban.RPC.GetEventsResponseTest do
   describe "new/1" do
     test "when successful transaction", %{result: result} do
       %GetEventsResponse{
-        latest_ledger: "669450",
+        latest_ledger: 45_075_181,
         events: [
           %{
             contract_id: "6e34123e6328b38075f4e670175221452db7535ceeb3def1af6dddc232c1eae4",

--- a/test/rpc/responses/get_ledger_entries_response_test.exs
+++ b/test/rpc/responses/get_ledger_entries_response_test.exs
@@ -13,7 +13,7 @@ defmodule Soroban.RPC.GetLedgerEntriesResponseTest do
             last_modified_ledger_seq: "13"
           }
         ],
-        latest_ledger: "179436"
+        latest_ledger: 45_075_181
       }
     }
   end

--- a/test/rpc/responses/get_transaction_response_test.exs
+++ b/test/rpc/responses/get_transaction_response_test.exs
@@ -6,7 +6,7 @@ defmodule Soroban.RPC.GetTransactionResponseTest do
   setup do
     not_found_result = %{
       status: :not_found,
-      latest_ledger: "45075181",
+      latest_ledger: 45_075_181,
       latest_ledger_close_time: "1677115742",
       oldest_ledger: "45070000",
       oldest_ledger_close_time: "1677000000"
@@ -14,7 +14,7 @@ defmodule Soroban.RPC.GetTransactionResponseTest do
 
     success_result = %{
       status: :success,
-      latest_ledger: "45075181",
+      latest_ledger: 45_075_181,
       latest_ledger_close_time: "1677115742",
       oldest_ledger: "45070000",
       oldest_ledger_close_time: "1677000000",
@@ -32,7 +32,7 @@ defmodule Soroban.RPC.GetTransactionResponseTest do
 
     failed_result = %{
       status: "FAILED",
-      latest_ledger: "45075181",
+      latest_ledger: 45_075_181,
       latest_ledger_close_time: "1677115742",
       oldest_ledger: "45070000",
       oldest_ledger_close_time: "1677000000",

--- a/test/rpc/responses/send_transaction_response_test.exs
+++ b/test/rpc/responses/send_transaction_response_test.exs
@@ -7,7 +7,7 @@ defmodule Soroban.RPC.SendTransactionResponseTest do
     result = %{
       hash: "d70916f8b8aa55c13d5974a38e32a3efe440ef6870c0f0a07075d1c128d23698",
       status: :pending,
-      latest_ledger: "45075181",
+      latest_ledger: 45_075_181,
       latest_ledger_close_time: "1677115742"
     }
 

--- a/test/rpc/responses/simulate_transaction_response_test.exs
+++ b/test/rpc/responses/simulate_transaction_response_test.exs
@@ -25,19 +25,22 @@ defmodule Soroban.RPC.SimulateTransactionResponseTest do
     cost = %{cpu_insns: "2222468", mem_bytes: "2204681"}
     error_cost = %{cpu_insns: "0", mem_bytes: "0"}
 
-    latest_ledger = "23456"
+    latest_ledger = 23456
     error = "Could not unmarshal transaction"
 
+    attrs = %{
+      transaction_data: transaction_data,
+      events: events,
+      min_resource_fee: min_resource_fee,
+      results: results,
+      cost: cost,
+      latest_ledger: latest_ledger
+    }
+
     %{
-      result: %{
-        transaction_data: transaction_data,
-        events: events,
-        min_resource_fee: min_resource_fee,
-        results: results,
-        cost: cost,
-        latest_ledger: latest_ledger
-      },
-      error_result: %{cost: error_cost, latest_ledger: "0", error: error}
+      attrs: attrs,
+      result: %{attrs | min_resource_fee: String.to_integer(min_resource_fee)},
+      error_result: %{cost: error_cost, latest_ledger: 0, error: error}
     }
   end
 

--- a/test/rpc/responses/simulate_transaction_response_test.exs
+++ b/test/rpc/responses/simulate_transaction_response_test.exs
@@ -25,7 +25,7 @@ defmodule Soroban.RPC.SimulateTransactionResponseTest do
     cost = %{cpu_insns: "2222468", mem_bytes: "2204681"}
     error_cost = %{cpu_insns: "0", mem_bytes: "0"}
 
-    latest_ledger = 23456
+    latest_ledger = 23_456
     error = "Could not unmarshal transaction"
 
     attrs = %{

--- a/test/rpc/responses/simulate_transaction_response_test.exs
+++ b/test/rpc/responses/simulate_transaction_response_test.exs
@@ -46,15 +46,15 @@ defmodule Soroban.RPC.SimulateTransactionResponseTest do
 
   describe "new/1" do
     test "when successful transaction", %{
-      result:
-        %{
-          transaction_data: transaction_data,
-          events: events,
-          min_resource_fee: min_resource_fee,
-          results: results,
-          cost: cost,
-          latest_ledger: latest_ledger
-        } = result
+      result: %{
+        transaction_data: transaction_data,
+        events: events,
+        min_resource_fee: min_resource_fee,
+        results: results,
+        cost: cost,
+        latest_ledger: latest_ledger
+      },
+      attrs: attrs
     } do
       %SimulateTransactionResponse{
         transaction_data: ^transaction_data,
@@ -63,7 +63,7 @@ defmodule Soroban.RPC.SimulateTransactionResponseTest do
         results: ^results,
         cost: ^cost,
         latest_ledger: ^latest_ledger
-      } = SimulateTransactionResponse.new(result)
+      } = SimulateTransactionResponse.new(attrs)
     end
 
     test "when error transaction", %{

--- a/test/rpc_test.exs
+++ b/test/rpc_test.exs
@@ -11,7 +11,7 @@ defmodule Soroban.RPC.CannedRPCSendTransactionClientImpl do
      %{
        status: "PENDING",
        hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-       latest_ledger: "476420",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683150612"
      }}
   end
@@ -38,7 +38,7 @@ defmodule Soroban.RPC.CannedRPCSimulateTransactionClientImpl do
          }
        ],
        cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-       latest_ledger: "475528"
+       latest_ledger: 45_075_181
      }}
   end
 end
@@ -113,7 +113,7 @@ defmodule Soroban.RPC.CannedRPCGetLedgerEntriesClientImpl do
            last_modified_ledger_seq: "13"
          }
        ],
-       latest_ledger: "179436"
+       latest_ledger: 45_075_181
      }}
   end
 end
@@ -129,7 +129,7 @@ defmodule Soroban.RPC.CannedRPCGetEventsClientImpl do
 
     {:ok,
      %{
-       latest_ledger: "685196",
+       latest_ledger: 45_075_181,
        events: [
          %{
            contract_id: "CCEMOFO5TE7FGOAJOA3RDHPC6RW3CFXRVIGOFQPFE4ZGOKA2QEA636SN",
@@ -164,7 +164,7 @@ defmodule Soroban.RPC.CannedRPCGetTransactionClientImpl do
     {:ok,
      %{
        status: "SUCCESS",
-       latest_ledger: "476536",
+       latest_ledger: 45_075_181,
        latest_ledger_close_time: "1683151229",
        oldest_ledger: "475097",
        oldest_ledger_close_time: "1683143656",
@@ -236,7 +236,7 @@ defmodule Soroban.RPCTest do
            }
          ],
          cost: %{cpu_insns: "1048713", mem_bytes: "1201148"},
-         latest_ledger: "475528",
+         latest_ledger: 45_075_181,
          error: nil
        }} = RPC.simulate_transaction(base64_envelope)
     end
@@ -261,7 +261,7 @@ defmodule Soroban.RPCTest do
        %SendTransactionResponse{
          status: "PENDING",
          hash: "a4721e2a61e9a6b3f54030396e41c3e352101e6cd649b4453e89fb3e827744f4",
-         latest_ledger: "476420",
+         latest_ledger: 45_075_181,
          latest_ledger_close_time: "1683150612",
          error_result_xdr: nil
        }} = RPC.send_transaction(base64_envelope)
@@ -285,7 +285,7 @@ defmodule Soroban.RPCTest do
       {:ok,
        %GetTransactionResponse{
          status: "SUCCESS",
-         latest_ledger: "476536",
+         latest_ledger: 45_075_181,
          latest_ledger_close_time: "1683151229",
          oldest_ledger: "475097",
          oldest_ledger_close_time: "1683143656",
@@ -374,7 +374,7 @@ defmodule Soroban.RPCTest do
              last_modified_ledger_seq: "13"
            }
          ],
-         latest_ledger: "179436"
+         latest_ledger: 45_075_181
        }} = RPC.get_ledger_entries(keys)
     end
   end
@@ -410,7 +410,7 @@ defmodule Soroban.RPCTest do
     test "request/1", %{event: event} do
       {:ok,
        %GetEventsResponse{
-         latest_ledger: "685196",
+         latest_ledger: 45_075_181,
          events: [
            %{
              contract_id: "CCEMOFO5TE7FGOAJOA3RDHPC6RW3CFXRVIGOFQPFE4ZGOKA2QEA636SN",


### PR DESCRIPTION
## Description

I was getting the `txSorobanInvalid` error when invoking a contract. This error was due to the percentages to increase resources, it was needed in the past. But now it is not.


Other changes:
SimulateTransactionResponse:
- Added `restore_preamble` field.
- Changed `latest_ledger` typespec to non negative integer.
- Parsed `min_resource_fee` from string to integer. Changed typespec too.




## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
